### PR TITLE
Skip unnecessary jobs

### DIFF
--- a/.github/workflows/operational-test.yml
+++ b/.github/workflows/operational-test.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   test: # make sure the action works on a clean machine without building
+    # Skip the job if the comment does not conatin the trigger phrase
+    if: contains(github.event.comment.body, '@github-actions run')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ on:
 
 jobs:
   comment-run:
+    # Skip the job if the comment does not conatin the trigger phrase
+    if: contains(github.event.comment.body, '@github-actions run')
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Skip the job when the trigger phrase is missing in a comment.